### PR TITLE
[IOS-530] The app crashes when you comment

### DIFF
--- a/Inbbbox/Source Files/Managers/ShotDetailsPageViewControllerDataSource.swift
+++ b/Inbbbox/Source Files/Managers/ShotDetailsPageViewControllerDataSource.swift
@@ -54,7 +54,7 @@ class ShotDetailsPageViewControllerDataSource: NSObject, UIPageViewControllerDat
                             viewControllerBeforeViewController viewController: UIViewController) -> UIViewController? {
         if let currentController = viewController as? ShotDetailsViewController where
             currentController.shotIndex > 0 {
-            return getShotDetailsViewController(atIndexPath: NSIndexPath(forItem: currentController.shotIndex - 1, inSection: 0)) as? ShotDetailsViewController
+            return getShotDetailsViewController(atIndexPath: NSIndexPath(forItem: currentController.shotIndex - 1, inSection: 0))
         }
         return nil
     }

--- a/Inbbbox/Source Files/Views/Controllers View/ShotDetailsView.swift
+++ b/Inbbbox/Source Files/Views/Controllers View/ShotDetailsView.swift
@@ -93,4 +93,8 @@ class ShotDetailsView: UIView {
     func customizeFor3DTouch(hidden: Bool) {
         backgroundColor = hidden ? .backgroundGrayColor() : .clearColor()
     }
+    
+    func hideKeyboard() {
+        commentComposerView.makeInactive()
+    }
 }

--- a/Inbbbox/Source Files/Views/Custom/KeyboardResizableView.swift
+++ b/Inbbbox/Source Files/Views/Custom/KeyboardResizableView.swift
@@ -69,7 +69,7 @@ class KeyboardResizableView: UIView {
     private var initialBottomConstraintConstant = CGFloat(0)
     private var bottomConstraint: NSLayoutConstraint?
     private var snapOffset = CGFloat(0)
-    
+
     init() {
         super.init(frame: CGRect.zero)
 
@@ -144,7 +144,7 @@ private extension KeyboardResizableView {
         
         let state: KeyboardState = keyboardPresence ? .WillAppear : .WillDisappear
         delegate?.keyboardResizableView(self, willRelayoutSubviewsWithState: state)
-        
+
         UIView.animateWithDuration(animationDuration.doubleValue, animations: {
             self.layoutIfNeeded()
         }) {


### PR DESCRIPTION
### Ticket
[IOS-530](https://netguru.atlassian.net/browse/IOS-530)


### Task Description
Fix but that was occuring when keyboard was appearing in `ShotDetailsView`

### Task Additional Notes
Turns out that when we did opened shot details view, swapped between shots and tapped comment space then keyboard notification was sent to all `ShotDetailsView`. To all that have been created during swapping, but not all of them did call `updateConstraints` so not all of them did set `bottomConstraint` in their `KeyboardResizableView` which was force unwrapped. Now this situation is handled properly with guard and optional.

Next to do step should be refactoring of `KeyboardResizeableView` in That way only visible view will observe notifications from keyboard events.