### PR TITLE
[IOS-535] Crash when application was paused during debugging

### DIFF
--- a/Inbbbox/Source Files/Networking/DataDownloader.swift
+++ b/Inbbbox/Source Files/Networking/DataDownloader.swift
@@ -42,17 +42,15 @@ extension DataDownloader: NSURLSessionDataDelegate {
     }
 
     func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveData data: NSData) {
-        self.data.appendData(data) //NGRFixme: During test this line cause crases once or twice with memory allocation, better remember about it.
-        let progress = Float(self.data.length) / totalSize
-        if progress != 1 {
-            if self.progress != nil {
-                self.progress!(progress)
-                return
-            }
+        let percentOfProgress = Float(self.data.length) / totalSize
+        
+        guard percentOfProgress < 1 else {
+            completion?(NSData(data: self.data))
+            session.invalidateAndCancel()
+            return
         }
-        if let completion = self.completion {
-            completion(NSData(data: self.data))
-            self.session?.finishTasksAndInvalidate()
-        }
+        
+        self.data.appendData(data)
+        progress?(percentOfProgress)
     }
 }


### PR DESCRIPTION
### Ticket
[IOS-535](https://netguru.atlassian.net/browse/IOS-535)


### Task Description
Fixed situation when `self.data` is not available with little refactor.

