### PR TITLE
[IOS-558] Crash in KeyboardResizableView

### DIFF
--- a/Inbbbox/Source Files/ViewControllers/ShotDetailsViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/ShotDetailsViewController.swift
@@ -121,6 +121,7 @@ final class ShotDetailsViewController: UIViewController {
         super.viewWillDisappear(animated)
         header?.cancelAllAnimatedImageSettings()
         willDismissDetailsCompletionHandler?(shotIndex)
+        shotDetailsView?.hideKeyboard()
     }
 
     func scrollViewWillEndDragging(_ scrollView: UIScrollView,

--- a/Inbbbox/Source Files/Views/Custom/KeyboardResizableView.swift
+++ b/Inbbbox/Source Files/Views/Custom/KeyboardResizableView.swift
@@ -158,9 +158,11 @@ private extension KeyboardResizableView {
     
     func calculateConstantIn(bottomConstraint: NSLayoutConstraint, basedOnParameters parameters: NSDictionary, andKeyboardPresence keyboardPresence: Bool) -> CGFloat {
         
+        guard let superview = superview else { return 0 }
+        
         if automaticallySnapToKeyboardTopEdge && !isKeyboardPresent {
-            let rectInSuperviewCoordinateSpace = superview!.convert(bounds, to: self)
-            let keyboardTopEdgeAndSelfBottomEdgeOffsetY = superview!.frame.height - rectInSuperviewCoordinateSpace.height + rectInSuperviewCoordinateSpace.minY
+            let rectInSuperviewCoordinateSpace = superview.convert(bounds, to: self)
+            let keyboardTopEdgeAndSelfBottomEdgeOffsetY = superview.frame.height - rectInSuperviewCoordinateSpace.height + rectInSuperviewCoordinateSpace.minY
             
             snapOffset = keyboardTopEdgeAndSelfBottomEdgeOffsetY
         }


### PR DESCRIPTION
### Ticket
[IOS-558](https://netguru.atlassian.net/browse/IOS-558)


### Task Description
Second attempt to PR #350 
Fixed issue when forced unwrapped superview was nil with guard.
Readded keyboard dismiss at shotDetailView will disappear.