### PR TITLE
[IOS-536] Reverting c35f04e

### DIFF
--- a/Inbbbox/Source Files/Managers/Shots State Handlers/ShotsNormalStateHandler.swift
+++ b/Inbbbox/Source Files/Managers/Shots State Handlers/ShotsNormalStateHandler.swift
@@ -124,29 +124,21 @@ extension ShotsNormalStateHandler {
             switch action {
             case .like:
                 firstly {
-                    cell.liked = true
-                    return Promise(value: Void())
-                }.then {
-                    certainSelf.setLikesInAuthorView(for: cell)
-                }.then {
                     certainSelf.likeShot(shot)
                 }.then {
-                    certainSelf.didLikeShotCompletionHandler?()
+                    cell.liked = true
+                }.then {
+                    self?.didLikeShotCompletionHandler?()
                 }.catch { error in
                     cell.liked = false
-                    let _ = certainSelf.unsetLikesInAuthorView(for: cell)
                 }
             case .bucket:
                 firstly {
-                    cell.liked = true
-                    return Promise(value: Void())
-                }.then {
-                    certainSelf.setLikesInAuthorView(for: cell)
-                }.then {
                     certainSelf.likeShot(shot)
+                }.then {
+                    cell.liked = true
                 }.catch { error in
                     cell.liked = false
-                    let _ = certainSelf.unsetLikesInAuthorView(for: cell)
                 }
                 certainSelf.presentShotBucketsViewController(shot)
             case .comment:
@@ -462,18 +454,6 @@ private extension ShotsNormalStateHandler {
                 connectionsRequester.followUser(shot.user)
             }.then(execute: fulfill).catch(execute: reject)
         }
-    }
-
-    func setLikesInAuthorView(for cell: ShotCollectionViewCell) -> Promise<Void> {
-        cell.authorView.incrementLikesNumber()
-        cell.authorView.setLikesIconActive()
-        return Promise(value: Void())
-    }
-
-    func unsetLikesInAuthorView(for cell: ShotCollectionViewCell) -> Promise<Void> {
-        cell.authorView.decrementLikesNumber()
-        cell.authorView.setLikesIconInactive()
-        return Promise(value: Void())
     }
 }
 

--- a/Inbbbox/Source Files/Views/Custom/ShotAuthorCompactView.swift
+++ b/Inbbbox/Source Files/Views/Custom/ShotAuthorCompactView.swift
@@ -37,9 +37,9 @@ class ShotAuthorCompactView: UIView {
             let placeholder = UIImage(named: "ic-account-nopicture")
             avatarView.imageView.loadImageFromURL((viewData?.avatarURL)!, placeholderImage: placeholder)
             if let viewData = viewData, viewData.liked {
-                setLikesIconActive()
+                likesImageView.image = UIImage(named: "ic-like-details-active")
             } else {
-                setLikesIconInactive()
+                likesImageView.image = UIImage(named: "ic-likes-count")
             }
             likesLabel.text = "\(viewData?.likesCount ?? 0)"
             commentsLabel.text = "\(viewData?.commentsCount ?? 0)"
@@ -76,29 +76,7 @@ class ShotAuthorCompactView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: Internal
-
-    func setLikesIconActive() {
-        likesImageView.image = UIImage(named: "ic-like-details-active")
-    }
-
-    func setLikesIconInactive() {
-        likesImageView.image = UIImage(named: "ic-likes-count")
-    }
-
-    func incrementLikesNumber() {
-        if let currentCount = viewData?.likesCount {
-            likesLabel.text = "\(currentCount + 1)"
-        }
-    }
-
-    func decrementLikesNumber() {
-        if let currentCount = viewData?.likesCount {
-            likesLabel.text = "\(currentCount + 1)"
-        }
-    }
-
-    // MARK: Subclassing
+    // MARK: UIView
 
     override class var requiresConstraintBasedLayout: Bool {
         return true


### PR DESCRIPTION
### Ticket
[IOS-536](https://netguru.atlassian.net/browse/IOS-536)


### Task Description
<!-- What should and what actually happens. -->
This is revert of commit c35f04ed5628c357585b37ff56f0bdc1e5133be3 from PR #346.
346 introduced solution by just simply updating view before request was fired and in case of error, view state was reverted.
But this solution was wrong from the very beginning, just see this video: https://monosnap.com/file/8dQe3Z6gbJVKBhjt5U2cLdesltCsMu after scrolling `cellForItem` is called and view is configured with current data from model (which is not changed until we fetch new data, which of course can and will take some time).
Solution? We plan to implement cache mechanism([IOS-586](https://netguru.atlassian.net/browse/IOS-586)), mostly to reduce number of requests, and I think this will solve problem with feedback synchronisation.


### Aditional Notes (optional)
<!-- Provide any additional notes: related PRs, screenshots, et al.). -->