### PR TITLE
[IOS-540] 3D touch support for the older version of iPhones

### DIFF
--- a/Inbbbox/Source Files/Helpers/DeviceInfo.swift
+++ b/Inbbbox/Source Files/Helpers/DeviceInfo.swift
@@ -13,4 +13,10 @@ final class DeviceInfo {
     class func shouldDowngrade() -> Bool {
         return Device().isOneOf([Device.iPadMini, Device.iPhone4s])
     }
+    
+    class func notsupports3DTouch() -> Bool {
+        let iPhonesWithout3DTouch = [Device.iPhone6Plus, Device.iPhone6, Device.iPhone5s, Device.iPhone5, Device.iPhone4s]
+        let simulatorIPhoneWithout3DTouch = iPhonesWithout3DTouch.map() { Device.simulator($0) }
+        return Device().isOneOf(Device.allPads + Device.allPods + iPhonesWithout3DTouch + simulatorIPhoneWithout3DTouch)
+    }
 }

--- a/Inbbbox/Source Files/Helpers/DeviceInfo.swift
+++ b/Inbbbox/Source Files/Helpers/DeviceInfo.swift
@@ -13,10 +13,4 @@ final class DeviceInfo {
     class func shouldDowngrade() -> Bool {
         return Device().isOneOf([Device.iPadMini, Device.iPhone4s])
     }
-    
-    class func notsupports3DTouch() -> Bool {
-        let iPhonesWithout3DTouch = [Device.iPhone6Plus, Device.iPhone6, Device.iPhone5s, Device.iPhone5, Device.iPhone4s]
-        let simulatorIPhoneWithout3DTouch = iPhonesWithout3DTouch.map() { Device.simulator($0) }
-        return Device().isOneOf(Device.allPads + Device.allPods + iPhonesWithout3DTouch + simulatorIPhoneWithout3DTouch)
-    }
 }

--- a/Inbbbox/Source Files/Managers/Shots State Handlers/ShotsNormalStateHandler.swift
+++ b/Inbbbox/Source Files/Managers/Shots State Handlers/ShotsNormalStateHandler.swift
@@ -453,7 +453,7 @@ private extension ShotsNormalStateHandler {
             firstly {
                 connectionsRequester.followUser(shot.user)
             }.then {
-                self.vibrate(feedbackType: .success)
+                self.vibrate(with: .success)
             }.then(execute: fulfill).catch(execute: reject)
         }
     }

--- a/Inbbbox/Source Files/Protocols/Vibratable.swift
+++ b/Inbbbox/Source Files/Protocols/Vibratable.swift
@@ -7,14 +7,14 @@
 //
 
 protocol Vibratable {
-    func vibrate(feedbackType feedbackType: UINotificationFeedbackType)
+    func vibrate(with type: UINotificationFeedbackType)
 }
 
 extension Vibratable {
-    func vibrate(feedbackType feedbackType: UINotificationFeedbackType) {
+    func vibrate(with type: UINotificationFeedbackType) {
         if #available(iOS 10.0, *) {
             let generator = UINotificationFeedbackGenerator()
-            generator.notificationOccurred(feedbackType)
+            generator.notificationOccurred(type)
         }
     }
 }

--- a/Inbbbox/Source Files/ViewControllers/BucketsCollectionViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/BucketsCollectionViewController.swift
@@ -40,7 +40,7 @@ class BucketsCollectionViewController: UICollectionViewController {
         collectionView.registerClass(BucketCollectionViewCell.self, type: .cell)
         collectionView.emptyDataSetSource = self
 
-        support3DTouchIfNeeded()
+        add3DSupportForOlderDevices()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -153,8 +153,8 @@ class BucketsCollectionViewController: UICollectionViewController {
 
 private extension BucketsCollectionViewController {
     
-    func support3DTouchIfNeeded() {
-        guard DeviceInfo.notsupports3DTouch() else { return }
+    func add3DSupportForOlderDevices() {
+        guard traitCollection.forceTouchCapability == .unavailable else { return }
         peekPop = PeekPop(viewController: self)
         _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView!)
     }

--- a/Inbbbox/Source Files/ViewControllers/BucketsCollectionViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/BucketsCollectionViewController.swift
@@ -40,8 +40,7 @@ class BucketsCollectionViewController: UICollectionViewController {
         collectionView.registerClass(BucketCollectionViewCell.self, type: .cell)
         collectionView.emptyDataSetSource = self
 
-        peekPop = PeekPop(viewController: self)
-        _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView)
+        support3DTouchIfNeeded()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -152,6 +151,15 @@ class BucketsCollectionViewController: UICollectionViewController {
     }
 }
 
+private extension BucketsCollectionViewController {
+    
+    func support3DTouchIfNeeded() {
+        guard DeviceInfo.notsupports3DTouch() else { return }
+        peekPop = PeekPop(viewController: self)
+        _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView!)
+    }
+}
+
 extension BucketsCollectionViewController: BaseCollectionViewViewModelDelegate {
 
     func viewModelDidLoadInitialItems() {
@@ -244,11 +252,15 @@ extension BucketsCollectionViewController : PeekPopPreviewingDelegate {
     func previewingContext(_ previewingContext: PreviewingContext, viewControllerForLocation location: CGPoint) -> UIViewController? {
 
         guard
-            let indexPath = collectionView?.indexPathForItem(at: previewingContext.sourceView.convert(location, to: collectionView)),
-            let cell = collectionView?.cellForItem(at: indexPath)
+            let collectionView = collectionView,
+            let indexPath = collectionView.indexPathForItem(at: previewingContext.sourceView.convert(location, to: collectionView)),
+            let cell = collectionView.cellForItem(at: indexPath)
         else { return nil }
 
-        previewingContext.sourceRect = cell.contentView.bounds
+        let frame = cell.frame
+        let origin = collectionView.convert(cell.frame.origin, to: view)
+        previewingContext.sourceRect = CGRect(x: origin.x, y: origin.y, width: frame.width, height: frame.height)
+        
         return SimpleShotsCollectionViewController(bucket: viewModel.buckets[indexPath.item])
     }
 

--- a/Inbbbox/Source Files/ViewControllers/FolloweesCollectionViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/FolloweesCollectionViewController.swift
@@ -52,7 +52,7 @@ class FolloweesCollectionViewController: TwoLayoutsCollectionViewController {
         viewModel.delegate = self
         navigationItem.title = viewModel.title
 
-        support3DTouchIfNeeded()
+        add3DSupportForOlderDevices()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -150,8 +150,8 @@ class FolloweesCollectionViewController: TwoLayoutsCollectionViewController {
 
 private extension FolloweesCollectionViewController {
     
-    func support3DTouchIfNeeded() {
-        guard DeviceInfo.notsupports3DTouch() else { return }
+    func add3DSupportForOlderDevices() {
+        guard traitCollection.forceTouchCapability == .unavailable else { return }
         peekPop = PeekPop(viewController: self)
         _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView!)
     }

--- a/Inbbbox/Source Files/ViewControllers/FolloweesCollectionViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/FolloweesCollectionViewController.swift
@@ -52,8 +52,7 @@ class FolloweesCollectionViewController: TwoLayoutsCollectionViewController {
         viewModel.delegate = self
         navigationItem.title = viewModel.title
 
-        peekPop = PeekPop(viewController: self)
-        _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView)
+        support3DTouchIfNeeded()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -149,6 +148,15 @@ class FolloweesCollectionViewController: TwoLayoutsCollectionViewController {
     }
 }
 
+private extension FolloweesCollectionViewController {
+    
+    func support3DTouchIfNeeded() {
+        guard DeviceInfo.notsupports3DTouch() else { return }
+        peekPop = PeekPop(viewController: self)
+        _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView!)
+    }
+}
+
 extension FolloweesCollectionViewController: BaseCollectionViewViewModelDelegate {
 
     func viewModelDidLoadInitialItems() {
@@ -236,11 +244,15 @@ extension FolloweesCollectionViewController: PeekPopPreviewingDelegate {
     func previewingContext(_ previewingContext: PreviewingContext, viewControllerForLocation location: CGPoint) -> UIViewController? {
 
         guard
-            let indexPath = collectionView?.indexPathForItem(at: previewingContext.sourceView.convert(location, to: collectionView)),
-            let cell = collectionView?.cellForItem(at: indexPath)
+            let collectionView = collectionView,
+            let indexPath = collectionView.indexPathForItem(at: previewingContext.sourceView.convert(location, to: collectionView)),
+            let cell = collectionView.cellForItem(at: indexPath)
         else { return nil }
 
-        previewingContext.sourceRect = cell.contentView.bounds
+        let frame = cell.frame
+        let origin = collectionView.convert(cell.frame.origin, to: view)
+        previewingContext.sourceRect = CGRect(x: origin.x, y: origin.y, width: frame.width, height: frame.height)
+        
         let profileViewController = ProfileViewController(user: viewModel.followees[indexPath.item])
         profileViewController.hidesBottomBarWhenPushed = true
         return profileViewController

--- a/Inbbbox/Source Files/ViewControllers/ProfileViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/ProfileViewController.swift
@@ -124,6 +124,7 @@ class ProfileViewController: TwoLayoutsCollectionViewController {
         _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView)
 
         setupBackButton()
+        support3DTouchIfNeeded()
         viewModel.downloadInitialItems()
     }
 
@@ -382,6 +383,12 @@ private extension ProfileViewController {
         dismissClosure?()
         dismiss(animated: true, completion: nil)
     }
+    
+    func support3DTouchIfNeeded() {
+        guard DeviceInfo.notsupports3DTouch() else { return }
+        peekPop = PeekPop(viewController: self)
+        _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView!)
+    }
 }
 
 // MARK: UIViewControllerPreviewingDelegate
@@ -444,15 +451,17 @@ extension ProfileViewController: PeekPopPreviewingDelegate {
             let cell = collectionView.cellForItem(at: indexPath)
         else { return nil }
 
+        let frame = cell.frame
+        let origin = collectionView.convert(cell.frame.origin, to: view)
+        previewingContext.sourceRect = CGRect(x: origin.x, y: origin.y, width: frame.width, height: frame.height)
+        
         if let viewModel = viewModel as? UserDetailsViewModel {
-            previewingContext.sourceRect = cell.contentView.bounds
             let controller = ShotDetailsViewController(shot: viewModel.shotWithSwappedUser(viewModel.userShots[indexPath.item]))
             controller.customizeFor3DTouch(true)
             controller.shotIndex = indexPath.item
 
             return controller
         } else if let viewModel = viewModel as? TeamDetailsViewModel, collectionView.collectionViewLayout is TwoColumnsCollectionViewFlowLayout {
-            previewingContext.sourceRect = cell.contentView.bounds
             return ProfileViewController(user: viewModel.teamMembers[indexPath.item])
         }
         return nil

--- a/Inbbbox/Source Files/ViewControllers/ProfileViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/ProfileViewController.swift
@@ -124,7 +124,7 @@ class ProfileViewController: TwoLayoutsCollectionViewController {
         _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView)
 
         setupBackButton()
-        support3DTouchIfNeeded()
+        add3DSupportForOlderDevices()
         viewModel.downloadInitialItems()
     }
 
@@ -384,8 +384,8 @@ private extension ProfileViewController {
         dismiss(animated: true, completion: nil)
     }
     
-    func support3DTouchIfNeeded() {
-        guard DeviceInfo.notsupports3DTouch() else { return }
+    func add3DSupportForOlderDevices() {
+        guard traitCollection.forceTouchCapability == .unavailable else { return }
         peekPop = PeekPop(viewController: self)
         _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView!)
     }

--- a/Inbbbox/Source Files/ViewControllers/ShotBucketsViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/ShotBucketsViewController.swift
@@ -311,7 +311,7 @@ private extension ShotBucketsViewController {
             viewModel.addShotToBucketAtIndex(index)
         }.then { () -> Void in
             self.willDismissViewControllerClosure?()
-            self.vibrate(feedbackType: .success)
+            self.vibrate(with: .success)
             self.dismiss(animated: true, completion: nil)
         }.catch { error in
             FlashMessage.sharedInstance.showNotification(inViewController: self, title: FlashMessageTitles.bucketProcessingFailed, canBeDismissedByUser: true)

--- a/Inbbbox/Source Files/ViewControllers/ShotsCollectionViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/ShotsCollectionViewController.swift
@@ -66,9 +66,7 @@ extension ShotsCollectionViewController {
         registerToSettingsNotifications()
         setupStreamSourcesAnimators()
         setupSkipButton()
-        
-        peekPop = PeekPop(viewController: self)
-        _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView!)
+        support3DTouchIfNeeded()
     }
     
     
@@ -277,6 +275,12 @@ fileprivate extension ShotsCollectionViewController {
     func scrollToShotAtIndex(_ index: Int, animated: Bool = true) {
         collectionView?.scrollToItem(at: IndexPath(item: index, section: 0), at: .centeredVertically, animated: animated)
     }
+    
+    func support3DTouchIfNeeded() {
+        guard DeviceInfo.notsupports3DTouch() else { return }
+        peekPop = PeekPop(viewController: self)
+        _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView!)
+    }
 }
 
 // MARK: UIViewControllerPreviewingDelegate
@@ -309,12 +313,15 @@ extension ShotsCollectionViewController: PeekPopPreviewingDelegate {
 
     func previewingContext(_ previewingContext: PreviewingContext, viewControllerForLocation location: CGPoint) -> UIViewController? {
         guard
-            let visibleCell = collectionView?.visibleCells.first,
+            let collectionView = collectionView,
+            let visibleCell = collectionView.visibleCells.first,
             let normalStateHandler = stateHandler as? ShotsNormalStateHandler,
-            let indexPath = collectionView?.indexPathsForVisibleItems.first
+            let indexPath = collectionView.indexPathsForVisibleItems.first
         else { return nil }
 
-        previewingContext.sourceRect = visibleCell.contentView.bounds
+        let frame = visibleCell.contentView.frame
+        let origin = collectionView.convert(visibleCell.frame.origin, to: view)
+        previewingContext.sourceRect = CGRect(x: origin.x, y: origin.y, width: frame.width, height: frame.height)
 
         return normalStateHandler.getShotDetailsViewController(atIndexPath: indexPath)
     }

--- a/Inbbbox/Source Files/ViewControllers/ShotsCollectionViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/ShotsCollectionViewController.swift
@@ -232,11 +232,11 @@ fileprivate extension ShotsCollectionViewController {
         if let normalStateHandler = stateHandler as? ShotsNormalStateHandler, let centerButtonTabBarController = tabBarController as? CenterButtonTabBarController {
             normalStateHandler.didLikeShotCompletionHandler = {
                 centerButtonTabBarController.animateTabBarItem(.likes)
-                self.vibrate(feedbackType: .success)
+                self.vibrate(with: .success)
             }
             normalStateHandler.didAddShotToBucketCompletionHandler = {
                 centerButtonTabBarController.animateTabBarItem(.buckets)
-                self.vibrate(feedbackType: .success)
+                self.vibrate(with: .success)
             }
             normalStateHandler.willDismissDetailsCompletionHandler = { [unowned self] index in
                 self.scrollToShotAtIndex(index, animated: false)

--- a/Inbbbox/Source Files/ViewControllers/ShotsCollectionViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/ShotsCollectionViewController.swift
@@ -66,7 +66,7 @@ extension ShotsCollectionViewController {
         registerToSettingsNotifications()
         setupStreamSourcesAnimators()
         setupSkipButton()
-        support3DTouchIfNeeded()
+        add3DSupportForOlderDevices()
     }
     
     
@@ -276,8 +276,8 @@ fileprivate extension ShotsCollectionViewController {
         collectionView?.scrollToItem(at: IndexPath(item: index, section: 0), at: .centeredVertically, animated: animated)
     }
     
-    func support3DTouchIfNeeded() {
-        guard DeviceInfo.notsupports3DTouch() else { return }
+    func add3DSupportForOlderDevices() {
+        guard traitCollection.forceTouchCapability == .unavailable else { return }
         peekPop = PeekPop(viewController: self)
         _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView!)
     }

--- a/Inbbbox/Source Files/ViewControllers/SimpleShotsCollectionViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/SimpleShotsCollectionViewController.swift
@@ -57,7 +57,7 @@ extension SimpleShotsCollectionViewController {
         collectionView.registerClass(SimpleShotCollectionViewCell.self, type: .cell)
         collectionView.emptyDataSetSource = self
         
-        support3DTouchIfNeeded()
+        add3DSupportForOlderDevices()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -73,8 +73,8 @@ extension SimpleShotsCollectionViewController {
 
 private extension SimpleShotsCollectionViewController {
     
-    func support3DTouchIfNeeded() {
-        guard DeviceInfo.notsupports3DTouch() else { return }
+    func add3DSupportForOlderDevices() {
+        guard traitCollection.forceTouchCapability == .unavailable else { return }
         peekPop = PeekPop(viewController: self)
         _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView!)
     }

--- a/Inbbbox/Source Files/ViewControllers/SimpleShotsCollectionViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/SimpleShotsCollectionViewController.swift
@@ -56,8 +56,8 @@ extension SimpleShotsCollectionViewController {
         }
         collectionView.registerClass(SimpleShotCollectionViewCell.self, type: .cell)
         collectionView.emptyDataSetSource = self
-        peekPop = PeekPop(viewController: self)
-        _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView)
+        
+        support3DTouchIfNeeded()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -68,6 +68,15 @@ extension SimpleShotsCollectionViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         viewModel?.downloadInitialItems()
+    }
+}
+
+private extension SimpleShotsCollectionViewController {
+    
+    func support3DTouchIfNeeded() {
+        guard DeviceInfo.notsupports3DTouch() else { return }
+        peekPop = PeekPop(viewController: self)
+        _ = peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView!)
     }
 }
 
@@ -119,12 +128,15 @@ extension SimpleShotsCollectionViewController: PeekPopPreviewingDelegate {
     func previewingContext(_ previewingContext: PreviewingContext, viewControllerForLocation location: CGPoint) -> UIViewController? {
 
         guard
-            let indexPath = collectionView?.indexPathForItem(at: previewingContext.sourceView.convert(location, to: collectionView)),
-            let cell = collectionView?.cellForItem(at: indexPath),
+            let collectionView = collectionView,
+            let indexPath = collectionView.indexPathForItem(at: previewingContext.sourceView.convert(location, to: collectionView)),
+            let cell = collectionView.cellForItem(at: indexPath),
             let viewModel = viewModel
         else { return nil }
 
-        previewingContext.sourceRect = cell.contentView.bounds
+        let frame = cell.frame
+        let origin = collectionView.convert(cell.frame.origin, to: view)
+        previewingContext.sourceRect = CGRect(x: origin.x, y: origin.y, width: frame.width, height: frame.height)
 
         let detailsViewController = ShotDetailsViewController(shot: viewModel.shots[indexPath.item])
         detailsViewController.customizeFor3DTouch(true)

--- a/Inbbbox/Source Files/ViewModels/ShotDetailsViewModel.swift
+++ b/Inbbbox/Source Files/ViewModels/ShotDetailsViewModel.swift
@@ -176,7 +176,7 @@ extension ShotDetailsViewModel: Vibratable {
                     shotLiked ? shotsRequester.unlikeShot(shot) : shotsRequester.likeShot(shot)
                 }.then { _ -> Void in
                     self.isShotLikedByMe = !shotLiked
-                    self.vibrate(feedbackType: .success)
+                    self.vibrate(with: .success)
                     fulfill(!shotLiked)
                 }.catch(execute: reject)
             }

--- a/Inbbbox/Source Files/ViewModels/TeamDetailsViewModel.swift
+++ b/Inbbbox/Source Files/ViewModels/TeamDetailsViewModel.swift
@@ -97,7 +97,7 @@ class TeamDetailsViewModel: ProfileViewModel, Vibratable {
             firstly {
                 connectionsRequester.followTeam(team)
             }.then {
-                self.vibrate(feedbackType: .success)
+                self.vibrate(with: .success)
             }.then(execute: fulfill).catch(execute: reject)
         }
     }

--- a/Inbbbox/Source Files/ViewModels/UserDetailsViewModel.swift
+++ b/Inbbbox/Source Files/ViewModels/UserDetailsViewModel.swift
@@ -101,7 +101,7 @@ class UserDetailsViewModel: ProfileViewModel, Vibratable {
             firstly {
                 connectionsRequester.followUser(user)
             }.then {
-                self.vibrate(feedbackType: .success)
+                self.vibrate(with: .success)
             }.then(execute: fulfill).catch(execute: reject)
         }
     }

--- a/Podfile
+++ b/Podfile
@@ -46,7 +46,7 @@ target 'Inbbbox' do
   pod 'AOAlertController', :git => 'https://github.com/0legAdamov/AOAlertController', :tag => 'v1.2.1'
   pod 'Solar', '~> 1.0.0'
   #fork until this will be discussed and merged https://github.com/marmelroy/PeekPop/pull/32/
-  pod 'PeekPop', :git => 'https://github.com/Myrenkar/PeekPop', :tag => '0.1.8'
+  pod 'PeekPop', :git => 'https://github.com/Myrenkar/PeekPop', :tag => '0.1.9'
 
   target 'Unit Tests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - Mockingjay/XCTest (2.0.0):
     - Mockingjay/Core
   - Nimble (5.1.1)
-  - PeekPop (0.1.8)
+  - PeekPop (1.0.0)
   - PromiseKit (4.0.5):
     - PromiseKit/Foundation (= 4.0.5)
     - PromiseKit/QuartzCore (= 4.0.5)
@@ -59,7 +59,7 @@ DEPENDENCIES:
   - Keys (from `Pods/CocoaPodsKeys`)
   - Mockingjay (~> 2.0)
   - Nimble (~> 5.0)
-  - PeekPop (from `https://github.com/Myrenkar/PeekPop`, tag `0.1.8`)
+  - PeekPop (from `https://github.com/Myrenkar/PeekPop`, tag `0.1.9`)
   - PromiseKit (~> 4.0)
   - PureLayout (~> 3.0)
   - Quick (~> 0.10)
@@ -85,7 +85,7 @@ EXTERNAL SOURCES:
     :path: Pods/CocoaPodsKeys
   PeekPop:
     :git: https://github.com/Myrenkar/PeekPop
-    :tag: 0.1.8
+    :tag: 0.1.9
 
 CHECKOUT OPTIONS:
   AOAlertController:
@@ -102,7 +102,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Siemian/ImageViewer
   PeekPop:
     :git: https://github.com/Myrenkar/PeekPop
-    :tag: 0.1.8
+    :tag: 0.1.9
 
 SPEC CHECKSUMS:
   AOAlertController: 937352719e3e9df03f0b6b9903665e1eaa76a558
@@ -120,7 +120,7 @@ SPEC CHECKSUMS:
   Keys: 9c35bf00f612ee1d48556f4a4b9b4551e224e90f
   Mockingjay: 7122a3fc0597aa63438e4cd9b71b7bc8aac05b87
   Nimble: 415e3aa3267e7bc2c96b05fa814ddea7bb686a29
-  PeekPop: 952f7193c35a1eacc041add712a24d54284b053d
+  PeekPop: f8d70aeefdc676881e04f388638e5e6751e0c354
   PromiseKit: 593b5e24ded6cbb1ebc708bc2c3428a8a5632d91
   PureLayout: 4d550abe49a94f24c2808b9b95db9131685fe4cd
   Quick: 5d290df1c69d5ee2f0729956dcf0fd9a30447eaa
@@ -131,6 +131,6 @@ SPEC CHECKSUMS:
   URITemplate: a5acb3f76c6a2338116fde88b658d83f91bbac45
   ZFDragableModalTransition: 0d294eaaba6edfcb9839595de765f9ca06a4b524
 
-PODFILE CHECKSUM: 3fd4783905568764c9e9b2e2fc63ff2680e4bfb6
+PODFILE CHECKSUM: 04668a7d4fec4e677bae95c420a31872b3bc95ad
 
 COCOAPODS: 1.1.1


### PR DESCRIPTION
### Ticket
[IOS-540](https://netguru.atlassian.net/browse/IOS-540)


### Task Description
Added 3D Touch support for iPhones below 6s, iPads, iPods.
Regarding to #345 now `previewContext` have proper origin also whole window is now in blurred view.
As minior change, parameter name in `Vibrateable` was changed from `vibrate(feedbackType feedbackType:)` to `vibrate(with type:`
