### PR TITLE
[IOS-637] Bug with LikedShot.hashValue

### DIFF
--- a/Inbbbox/Source Files/Model/LikedShot.swift
+++ b/Inbbbox/Source Files/Model/LikedShot.swift
@@ -44,6 +44,6 @@ func == (lhs: LikedShot, rhs: LikedShot) -> Bool {
 
 extension LikedShot: Hashable {
     var hashValue: Int {
-        return likeIdentifier.hashValue + createdAt.hashValue
+        return likeIdentifier.hashValue ^ createdAt.hashValue
     }
 }


### PR DESCRIPTION
### Ticket
[IOS-637](https://netguru.atlassian.net/browse/IOS-637)


### Task Description
This PR introduce:
- Fixed situation when creating `hashValue` for `LikedShot` casued crash.