### PR TITLE
IOS-649: App is logging out randomly after few actions

### DIFF
--- a/Inbbbox/Source Files/ViewControllers/ShotsCollectionViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/ShotsCollectionViewController.swift
@@ -91,8 +91,10 @@ extension ShotsCollectionViewController {
             }.then {
                 self.stateHandler.presentData()
             }.catch { error in
-                let alertController = UIAlertController.willSignOutUser()
-                self.tabBarController?.present(alertController, animated: true, completion: nil)
+                if self.stateHandler.state != .normal {
+                    let alertController = UIAlertController.willSignOutUser()
+                    self.tabBarController?.present(alertController, animated: true, completion: nil)
+                }
             }
         } else {
             shouldShowStreamSources = true


### PR DESCRIPTION
### Ticket
[IOS-649](https://netguru.atlassian.net/browse/IOS-649)

### Task Description
App logs out user when it exceeds request/min (or /day). This happened all the time, when main view was shown. 
I changed it to log out user only if state of main view is other than `normal`, cause in these states user can stuck in the app since TabBar's user interaction is disabled and when downloading shots fails, state is never changed.
