### PR TITLE
IOS-650: Changing between Night and Day modes sometimes fails.

### DIFF
--- a/Inbbbox/Source Files/Providers/ColorModeProvider.swift
+++ b/Inbbbox/Source Files/Providers/ColorModeProvider.swift
@@ -114,10 +114,11 @@ final class ColorModeProvider {
     fileprivate class func findCenterButtonTabControllerInWindows() -> CenterButtonTabBarController? {
         let windows = UIApplication.shared.windows as [UIWindow]
         for window in windows {
-            guard let centerButtonTabBarController = window.rootViewController as? CenterButtonTabBarController  else {
-                continue
+            if let centerButtonTabBarController = window.rootViewController as? CenterButtonTabBarController {
+                return centerButtonTabBarController
+            } else if let loginViewController = window.rootViewController as? LoginViewController {
+                return loginViewController.centerButtonTabBarController
             }
-            return centerButtonTabBarController
         }
         return nil
     }


### PR DESCRIPTION
### Ticket
[IOS-650](https://netguru.atlassian.net/browse/IOS-650)


### Task Description
Root view controller is not always of type `CenterButtonTabBarController`, but can also be `LoginViewController`.