### PR TITLE
[IOS-642] User's profile buckets segment label gets shrinked and buckets counter goes too much on the right

### DIFF
--- a/Inbbbox/Source Files/Views/Custom/ProfileMenuButton.swift
+++ b/Inbbbox/Source Files/Views/Custom/ProfileMenuButton.swift
@@ -52,7 +52,7 @@ class ProfileMenuButton: UIButton {
             badgeLabel.autoPinEdge(.leading, to: .trailing, of: titleLabel)
             badgeLabel.autoPinEdge(.bottom, to: .top, of: titleLabel, withOffset: 7)
             
-            if (titleLabel.intrinsicContentSize.width >= intrinsicContentSize.width) {
+            if (titleLabel.intrinsicContentSize.width + badgeLabel.intrinsicContentSize.width >= intrinsicContentSize.width) {
                 titleLabel.adjustsFontSizeToFitWidth = true
                 badgeLabel.autoPinEdge(toSuperviewEdge: .trailing, withInset: 8)
                 titleLabel.autoPinEdge(toSuperviewEdge: .leading, withInset: 8)


### PR DESCRIPTION
### Ticket
[IOS-642](https://netguru.atlassian.net/browse/IOS-642)


### Task Description
This PR introduce:
- fix for wrong width calculation
