### PR TITLE
IOS-670: Fix for 3D Touch preview

### DIFF
--- a/Inbbbox/Source Files/Providers/ColorModeProvider.swift
+++ b/Inbbbox/Source Files/Providers/ColorModeProvider.swift
@@ -74,7 +74,6 @@ final class ColorModeProvider {
         ProfileHeaderView.appearance().backgroundColor = mode.profileHeaderViewBackground
 
         UICollectionView.appearance().backgroundColor = mode.collectionViewBackgroundColor
-        UIScrollView.appearance().backgroundColor = mode.collectionViewBackgroundColor
         UINavigationBar.appearance().tintColor = UIColor.white
         UINavigationBar.appearance().barStyle = .black
         UINavigationBar.appearance().titleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]


### PR DESCRIPTION
### Ticket
[IOS-670](https://netguru.atlassian.net/browse/IOS-670)


### Task Description
AS IS:
When using a 3d touch a whole screen goes grey.
SHOULD BE:
3D Touch preview should blur the whole screen and magnify a previewed subview.


### Aditional Notes (optional)
Fix for this bug will break colors adaptation for night mode on the Profile / Info screen. A proper change handling will be introduced in a task [IOS-607](https://netguru.atlassian.net/browse/IOS-607)
