### PR TITLE
[IOS-642] User's profile buckets segment label gets shrinked and buckets counter goes too much on the right

### DIFF
--- a/Inbbbox/Source Files/Views/Custom/ProfileMenuBarView.swift
+++ b/Inbbbox/Source Files/Views/Custom/ProfileMenuBarView.swift
@@ -30,10 +30,10 @@ class ProfileMenuBarView: UIView {
 
         deselectAllItems()
 
-        shotsButton.setTitle(Localized("ProfileMenuBarView.Shots", comment: "Shots card title."), for: .normal)
-        infoButton.setTitle(Localized("ProfileMenuBarView.Info", comment: "Info card title."), for: .normal)
-        projectsButton.setTitle(Localized("ProfileMenuBarView.Projects", comment: "Projects card title."), for: .normal)
-        bucketsButton.setTitle(Localized("ProfileMenuBarView.Buckets", comment: "Buckets card title."), for: .normal)
+        shotsButton.title = Localized("ProfileMenuBarView.Shots", comment: "Shots card title.")
+        infoButton.title = Localized("ProfileMenuBarView.Info", comment: "Info card title.")
+        projectsButton.title = Localized("ProfileMenuBarView.Projects", comment: "Projects card title.")
+        bucketsButton.title = Localized("ProfileMenuBarView.Buckets", comment: "Buckets card title.")
 
         [shotsButton, infoButton, projectsButton, bucketsButton].forEach {
             $0.titleLabel?.font = UIFont.boldSystemFont(ofSize: 14)

--- a/Inbbbox/Source Files/Views/Custom/ProfileMenuButton.swift
+++ b/Inbbbox/Source Files/Views/Custom/ProfileMenuButton.swift
@@ -42,7 +42,6 @@ class ProfileMenuButton: UIButton {
     fileprivate let badgeLabel = UILabel()
     fileprivate let nameLabel = UILabel()
     fileprivate var didSetConstraints = false
-    fileprivate var nameTrailingConstraint: NSLayoutConstraint?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -65,14 +64,15 @@ class ProfileMenuButton: UIButton {
         if !didSetConstraints {
             didSetConstraints = true
 
+            let offset = CGFloat(4.0)
             badgeLabel.autoPinEdge(.leading, to: .trailing, of: nameLabel)
             badgeLabel.autoPinEdge(.bottom, to: .top, of: nameLabel, withOffset: 7)
-            badgeLabel.autoPinEdge(toSuperviewEdge: .trailing)
+            badgeLabel.autoPinEdge(toSuperviewEdge: .trailing, withInset: offset)
             
             nameLabel.adjustsFontSizeToFitWidth = true
-            nameLabel.autoPinEdge(toSuperviewEdge: .leading)
+            nameLabel.autoPinEdge(toSuperviewEdge: .leading, withInset: offset)
             nameLabel.autoAlignAxis(.horizontal, toSameAxisOf: self)
-            nameLabel.autoMatch(.width, to: .width, of: self, withOffset: -badgeLabel.intrinsicContentSize.width)
+            nameLabel.autoMatch(.width, to: .width, of: self, withOffset: -(badgeLabel.intrinsicContentSize.width + (offset * 2)) )
         }
 
         super.updateConstraints()

--- a/Inbbbox/Source Files/Views/Custom/ProfileMenuButton.swift
+++ b/Inbbbox/Source Files/Views/Custom/ProfileMenuButton.swift
@@ -15,7 +15,12 @@ class ProfileMenuButton: UIButton {
         didSet {
             badgeLabel.text = "\(badge)"
             badgeLabel.isHidden = badge == 0
-            titleEdgeInsets = UIEdgeInsets(top: 0, left: badge == 0 ? 0 : -3, bottom: 0, right: badge == 0 ? 0 : 3)
+            
+            if badge == 0 {
+                nameLabel.textAlignment = .center
+            } else {
+                nameLabel.textAlignment = .right
+            }
         }
     }
 
@@ -24,17 +29,30 @@ class ProfileMenuButton: UIButton {
             badgeLabel.textColor = badgeColor
         }
     }
+    
+    var title: String? {
+        get {
+            return nameLabel.text
+        }
+        set {
+            nameLabel.text = newValue
+        }
+    }
 
     fileprivate let badgeLabel = UILabel()
+    fileprivate let nameLabel = UILabel()
     fileprivate var didSetConstraints = false
+    fileprivate var nameTrailingConstraint: NSLayoutConstraint?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
 
         badgeLabel.font = UIFont.systemFont(ofSize: 10)
+        nameLabel.font = titleLabel?.font
+        nameLabel.textAlignment = .center
         
         addSubview(badgeLabel)
-        titleLabel?.textAlignment = .center
+        addSubview(nameLabel)
     }
 
     @available(*, unavailable, message: "Use init(frame:) instead")
@@ -47,16 +65,14 @@ class ProfileMenuButton: UIButton {
         if !didSetConstraints {
             didSetConstraints = true
 
-            guard let titleLabel = titleLabel else { return }
-
-            badgeLabel.autoPinEdge(.leading, to: .trailing, of: titleLabel)
-            badgeLabel.autoPinEdge(.bottom, to: .top, of: titleLabel, withOffset: 7)
+            badgeLabel.autoPinEdge(.leading, to: .trailing, of: nameLabel)
+            badgeLabel.autoPinEdge(.bottom, to: .top, of: nameLabel, withOffset: 7)
+            badgeLabel.autoPinEdge(toSuperviewEdge: .trailing)
             
-            if (titleLabel.intrinsicContentSize.width + badgeLabel.intrinsicContentSize.width >= intrinsicContentSize.width) {
-                titleLabel.adjustsFontSizeToFitWidth = true
-                badgeLabel.autoPinEdge(toSuperviewEdge: .trailing, withInset: 8)
-                titleLabel.autoPinEdge(toSuperviewEdge: .leading, withInset: 8)
-            }
+            nameLabel.adjustsFontSizeToFitWidth = true
+            nameLabel.autoPinEdge(toSuperviewEdge: .leading)
+            nameLabel.autoAlignAxis(.horizontal, toSameAxisOf: self)
+            nameLabel.autoMatch(.width, to: .width, of: self, withOffset: -badgeLabel.intrinsicContentSize.width)
         }
 
         super.updateConstraints()


### PR DESCRIPTION
### Ticket
[IOS-642](https://netguru.atlassian.net/browse/IOS-642)


### Task Description
This PR introduce:
- fix for situation when title of button or its badge is misplaced
