### PR TITLE
IOS-675: Check if bio characters count is greater than zero.

### DIFF
--- a/Inbbbox/Source Files/ViewModels/ProfileInfoViewModel.swift
+++ b/Inbbbox/Source Files/ViewModels/ProfileInfoViewModel.swift
@@ -56,7 +56,7 @@ final class ProfileInfoViewModel: BaseCollectionViewViewModel {
     }
 
     var bio: NSAttributedString? {
-        guard let body = NSAttributedString(htmlString: user.bio)?.attributedStringByTrimingTrailingNewLine() else {
+        guard user.bio.characters.count > 0, let body = NSAttributedString(htmlString: user.bio)?.attributedStringByTrimingTrailingNewLine() else {
             return nil
         }
         


### PR DESCRIPTION
### Ticket
[IOS-675](https://netguru.atlassian.net/browse/IOS-675)


### Task Description
Application did chrashed when user's bio has 0 characters.
Added check if bio characters count is greater than zero.

