### PR TITLE
IOS-701: App colors are broken while Auto Night Mode is selected

### DIFF
--- a/Inbbbox/Source Files/Providers/ColorModeProvider.swift
+++ b/Inbbbox/Source Files/Providers/ColorModeProvider.swift
@@ -32,7 +32,15 @@ final class ColorModeProvider {
     }
 
     class func current() -> ColorModeType {
-        let currentMode = Settings.Customization.CurrentColorMode
+
+        let currentMode: ColorMode = {
+            if Settings.Customization.AutoNightMode, let mode = NightModeHoursProvider.currentColorModeBasedOnTime() {
+                return mode
+            } else {
+                return Settings.Customization.CurrentColorMode
+            }
+        }()
+
         switch currentMode {
         case .dayMode: return DayMode()
         case .nightMode: return NightMode()


### PR DESCRIPTION
### Ticket
[IOS-701](https://netguru.atlassian.net/browse/IOS-701)

### Task Description
Fix for `App colors are broken while Auto Night Mode is selected`
