### PR TITLE
[IOS-703] Add missing NSPhotoLibraryUsageDescription to Info.plist

### DIFF
--- a/Supporting Files/Inbbbox-Info.plist
+++ b/Supporting Files/Inbbbox-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>To attach a photo to your feedback, we need access to your Photo Library.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>


### PR DESCRIPTION
### Ticket
[IOS-703](https://netguru.atlassian.net/browse/IOS-703)

### Task Description
This PR introduce:
- missing NSPhotoLibraryUsageDescription in Info.plist

### Aditional Notes (optional)
Regarding to https://www.hockeyapp.net/blog/2016/09/13/hockeysdk-ios-4-1-1-macos-tvos-4-1-0.html