### PR TITLE
IOS-705: Fix for blocking all following users

### DIFF
--- a/Inbbbox/Source Files/ViewControllers/BlockedUsersViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/BlockedUsersViewController.swift
@@ -33,6 +33,10 @@ class BlockedUsersViewController: UITableViewController {
 
         provideBlockedUsers()
     }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        _ = navigationController?.popViewController(animated: true)
+    }
 
     func provideBlockedUsers() -> Void {
         firstly {

--- a/Inbbbox/Source Files/ViewControllers/ShotsCollectionViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/ShotsCollectionViewController.swift
@@ -309,6 +309,8 @@ fileprivate extension ShotsCollectionViewController {
                         return authors.count == 0
                     })
                     fulfill(filteredShots)
+                } else {
+                    fulfill(shots)
                 }
             }.catch(execute: reject)
         }

--- a/Inbbbox/Source Files/ViewModels/BucketContentViewModel.swift
+++ b/Inbbbox/Source Files/ViewModels/BucketContentViewModel.swift
@@ -114,6 +114,8 @@ class BucketContentViewModel: SimpleShotsViewModel {
                         return authors.count == 0
                     })
                     fulfill(filteredShots)
+                } else {
+                    fulfill(shots)
                 }
             }.catch(execute: reject)
         }

--- a/Inbbbox/Source Files/ViewModels/BucketsViewModel.swift
+++ b/Inbbbox/Source Files/ViewModels/BucketsViewModel.swift
@@ -159,6 +159,8 @@ class BucketsViewModel: BaseCollectionViewViewModel {
                         return authors.count == 0
                     })
                     fulfill(filteredShots)
+                } else {
+                    fulfill(shots)
                 }
             }.catch(execute: reject)
         }

--- a/Inbbbox/Source Files/ViewModels/LikesViewModel.swift
+++ b/Inbbbox/Source Files/ViewModels/LikesViewModel.swift
@@ -111,6 +111,8 @@ class LikesViewModel: SimpleShotsViewModel {
                         return authors.count == 0
                     })
                     fulfill(filteredShots)
+                } else {
+                    fulfill(shots)
                 }
             }.catch(execute: reject)
         }


### PR DESCRIPTION
### Ticket
[IOS-705](https://netguru.atlassian.net/browse/IOS-705)


### Task Description
Apple notified us that we have a missing feature in the comments section regarding point 1.2 in Safety section. Long story short, we need to add a blocking mechanism for users that comments we do not want to see. Dribbble does not have such mechanism in their API. We have to create our own.


### Aditional Notes (optional)
After choosing FOLLOWING as a stream source on the dashboard, blocking all of the following users and returning to the dashboard, the app crashes. It should display the dashboard with no shots in it instead.
