### PR TITLE
IOS-705: Fix for blocked shots visible in my profile

### DIFF
--- a/Inbbbox/Source Files/ViewControllers/ProfileProjectsOrBucketsViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/ProfileProjectsOrBucketsViewController.swift
@@ -84,6 +84,7 @@ class ProfileProjectsOrBucketsViewController: UITableViewController, Support3DTo
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        viewModel.downloadInitialItems()
         addSupport3DForOlderDevicesIfNeeded(with: self, viewController: self, sourceView: tableView!)
     }
 }

--- a/Inbbbox/Source Files/ViewControllers/ShotDetailsViewController.swift
+++ b/Inbbbox/Source Files/ViewControllers/ShotDetailsViewController.swift
@@ -400,6 +400,8 @@ private extension ShotDetailsViewController {
                 if let blockedUsers = users {
                     let authors = blockedUsers.filter { $0.identifier == self.viewModel.shot.user.identifier }
                     fulfill(authors.count > 0)
+                } else {
+                    fulfill(false)
                 }
             }.catch(execute: reject)
         }

--- a/Unit Tests/ProfileBucketsViewModelSpec.swift
+++ b/Unit Tests/ProfileBucketsViewModelSpec.swift
@@ -16,7 +16,7 @@ class ProfileBucketsViewModelSpec: QuickSpec {
 
         var sut: ProfileBucketsViewModelMock!
         let fixtureBucketName = "fixture.name"
-        let fixtureNumberOfShots = "250"
+        let fixtureNumberOfShots = "1"
 
         beforeEach {
             sut = ProfileBucketsViewModelMock(user: User.fixtureUser())

--- a/Unit Tests/ProfileProjectsViewModelSpec.swift
+++ b/Unit Tests/ProfileProjectsViewModelSpec.swift
@@ -16,7 +16,7 @@ class ProfileProjectsViewModelSpec: QuickSpec {
 
         var sut: ProfileProjectsViewModelMock!
         let fixtureProjectName = "fixture.name"
-        let fixtureNumberOfShots = "4"
+        let fixtureNumberOfShots = "1"
 
         beforeEach {
             sut = ProfileProjectsViewModelMock(user: User.fixtureUser())


### PR DESCRIPTION
### Ticket
[IOS-705](https://netguru.atlassian.net/browse/IOS-705)


### Task Description
Apple notified us that we have a missing feature in the comments section regarding point 1.2 in Safety section. Long story short, we need to add a blocking mechanism for users that comments we do not want to see. Dribbble does not have such mechanism in their API. We have to create our own.


### Aditional Notes (optional)
After choosing SHOW MY PROFILE option in the settings shots from blocked users are visible but can't be open. They should not be visible at all.